### PR TITLE
[GRCUDA-4] Update name to GrCUDA

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -25,5 +25,5 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-grCUDA depends on Truffle APIs licensed under the Universal Permissive
+GrCUDA depends on Truffle APIs licensed under the Universal Permissive
 License (UPL), Version 1.0 (https://opensource.org/licenses/UPL).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grCUDA: Polyglot GPU Access in GraalVM
+# GrCUDA: Polyglot GPU Access in GraalVM
 
 This Truffle language exposes GPUs to the polyglot [GraalVM](http://www.graalvm.org). The goal is to
 
@@ -15,23 +15,23 @@ Supported and tested GraalVM languages:
 - Java
 - C and Rust through the Graal Sulong Component
 
-A description of grCUDA and its the features can be found in the [grCUDA documentation](docs/grcuda.md).
+A description of GrCUDA and its the features can be found in the [GrCUDA documentation](docs/grcuda.md).
 
 The [bindings documentation](docs/bindings.md) contains a tutorial that shows
 how to bind precompiled kernels to callables, compile and launch kernels.
 
 **Additional Information:**
 
-- [grCUDA: A Polyglot Language Binding for CUDA in GraalVM](https://devblogs.nvidia.com/grcuda-a-polyglot-language-binding-for-cuda-in-graalvm/). NVIDIA Developer Blog,
+- [GrCUDA: A Polyglot Language Binding for CUDA in GraalVM](https://devblogs.nvidia.com/grcuda-a-polyglot-language-binding-for-cuda-in-graalvm/). NVIDIA Developer Blog,
   November 2019.
-- [grCUDA: A Polyglot Language Binding](https://youtu.be/_lI6ubnG9FY). Presentation at Oracle CodeOne 2019, September 2019.
+- [GrCUDA: A Polyglot Language Binding](https://youtu.be/_lI6ubnG9FY). Presentation at Oracle CodeOne 2019, September 2019.
 - [Simplifying GPU Access](https://developer.nvidia.com/gtc/2020/video/s21269-vid). Presentation at NVIDIA GTC 2020, March 2020.
 - [DAG-based Scheduling with Resource Sharing for Multi-task Applications in a Polyglot GPU Runtime](https://ieeexplore.ieee.org/abstract/document/9460491). Paper at IPDPS 2021 on the GrCUDA scheduler, May 2021. [Video](https://youtu.be/QkX0FHDRyxA) of the presentation.
 
-## Using grCUDA in the GraalVM
+## Using GrCUDA in the GraalVM
 
-grCUDA can be used in the binaries of the GraalVM languages (`lli`, `graalpython`,
-`js`, `R`, and `ruby)`. The JAR file containing grCUDA must be appended to the classpath
+GrCUDA can be used in the binaries of the GraalVM languages (`lli`, `graalpython`,
+`js`, `R`, and `ruby)`. The JAR file containing GrCUDA must be appended to the classpath
 or copied into `jre/languages/grcuda` of the Graal installation. Note that `--jvm`
 and `--polyglot` must be specified in both cases as well.
 
@@ -47,7 +47,7 @@ __global__ void increment(int *arr, int n) {
     arr[idx] += 1;
   }
 }`
-const cu = Polyglot.eval('grcuda', 'CU') // get grCUDA namespace object
+const cu = Polyglot.eval('grcuda', 'CU') // get GrCUDA namespace object
 const incKernel = cu.buildkernel(
   kernelSource, // CUDA kernel source code string
   'increment', // kernel name
@@ -126,7 +126,7 @@ Documentation on [polyglot kernel launches](docs/launchkernel.md).
 
 ## Installation
 
-grCUDA can be downloaded as a binary JAR from [grcuda/releases](https://github.com/NVIDIA/grcuda/releases) and manually copied into a GraalVM installation.
+GrCUDA can be downloaded as a binary JAR from [grcuda/releases](https://github.com/NVIDIA/grcuda/releases) and manually copied into a GraalVM installation.
 
 1. Download GraalVM CE 21.1.0 for Linux `graalvm-ce-java11-linux-amd64-21.1.0.tar.gz`
    from [GitHub](https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-linux-amd64-21.1.0.tar.gz) and untar it in your
@@ -138,7 +138,7 @@ grCUDA can be downloaded as a binary JAR from [grcuda/releases](https://github.c
    export GRAALVM_DIR=`pwd`/graalvm-ce-java11-21.1.0
    ```
 
-2. Download the grCUDA JAR from [grcuda/releases](https://github.com/NVIDIA/grcuda/releases). If using the official release, the latest features (e.g. the asynchronous scheduler) are not available. Instead, follow the guide below to install GrCUDA from the source code.
+2. Download the GrCUDA JAR from [grcuda/releases](https://github.com/NVIDIA/grcuda/releases). If using the official release, the latest features (e.g. the asynchronous scheduler) are not available. Instead, follow the guide below to install GrCUDA from the source code.
 
    ```console
    cd $GRAALVM_DIR/jre/languages
@@ -146,7 +146,7 @@ grCUDA can be downloaded as a binary JAR from [grcuda/releases](https://github.c
    cp <download folder>/grcuda-0.1.0.jar grcuda
    ```
 
-3. Test grCUDA in Node.JS from GraalVM.
+3. Test GrCUDA in Node.JS from GraalVM.
 
    ```console
    cd $GRAALVM_DIR/bin
@@ -165,13 +165,13 @@ grCUDA can be downloaded as a binary JAR from [grcuda/releases](https://github.c
    ./gu install ruby
    ```
 
-## Instructions to build grCUDA from Sources
+## Instructions to build GrCUDA from Sources
 
-grCUDA requires the [mx build tool](https://github.com/graalvm/mx). Clone the mx
+GrCUDA requires the [mx build tool](https://github.com/graalvm/mx). Clone the mx
 repository and add the directory into `$PATH`, such that the `mx` can be invoked from
 the command line.
 
-Build grCUDA and the unit tests:
+Build GrCUDA and the unit tests:
 
 ```console
 cd <directory containing this README>
@@ -186,7 +186,7 @@ To run unit tests:
 mx unittest com.nvidia
 ```
 
-## Using grCUDA in a JDK
+## Using GrCUDA in a JDK
 
 Make sure that you use the [OpenJDK+JVMCI-21.1](https://github.com/graalvm/labs-openjdk-11/releases/download/jvmci-21.1-b05/labsjdk-ce-11.0.11+8-jvmci-21.1-b05-linux-amd64.tar.gz).
 

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -3,7 +3,7 @@
 GPU kernels and host function can be executed as function calls.
 The corresponding functions are callable objects that are bound
 to the respective kernel or host functions.
-grCUDA provides different ways to define these bindings:
+GrCUDA provides different ways to define these bindings:
 
 - `bind(shareLibraryFile, functionNameAndSignature)` returns a callable
   object to the specified host function defined in the shared library (.so file).
@@ -11,20 +11,20 @@ grCUDA provides different ways to define these bindings:
   to specified kernel function defined in PTX or cubin file.
 - `bindall(targetNamespace, fileName, nidlFileName)` registers all functions
   listed in the NIDL (Native Interface Definition Language) for the
-  specified binary file into the target namespace of grCUDA.
+  specified binary file into the target namespace of GrCUDA.
 
 The first two approaches are useful to implement the one-off binding to
 a native function, be it a kernel or a host function. `bindall()` is use
 to bind multiple functions from the same binary or PTX file. This tutorial shows
 how to call existing native host functions and kernels from GraalVM languages
-through grCUDA.
+through GrCUDA.
 
 ## Binding and Invoking prebuilt Host Functions
 
 Host functions can be bound from existing shared libraries by `bind()` or
 `bindall()`. The former returns one single native function as a callable object
 whereas later binds can be used to bind multiple functions into a specified
-namespace within grCUDA.
+namespace within GrCUDA.
 
 This simple example shows how to call two host functions from a shared library.
 One function is defined a C++ namespace. The other function is defined as
@@ -73,7 +73,7 @@ Build the shared library (Linux).
 nvcc -o libincrement.so -std=c++11 --shared -Xcompiler -fPIC increment.cu
 ```
 
-`bind()` can be used to "import" a single function into grCUDA as shown in
+`bind()` can be used to "import" a single function into GrCUDA as shown in
 the following NodeJS/JavaScript example.
 
 ```javascript
@@ -107,7 +107,7 @@ for (const el of deviceArray) {
 
 `bind()` takes the name (or path) of the shared library. The second argument
 specifies the signature in NIDL format. Add the keyword `cxx` for C++ style functions. The C++ namespace can be specified using `::`. Without `cxx`
-grCUDA assumes C linkage of the function and does not apply any name mangling.
+GrCUDA assumes C linkage of the function and does not apply any name mangling.
 `bind()` returns the function objects as callables, i.e., `TruffleObject`
 instances for which `isExecutable()` is `true`.
 
@@ -191,7 +191,7 @@ nvcc -cubin -gencode=arch=compute_75,code=sm_75 \
    -o increment.cubin increment_kernels.cu
 ```
 
-`bindkernel()` "imports" a single kernel function into grCUDA. `bindkernel()`
+`bindkernel()` "imports" a single kernel function into GrCUDA. `bindkernel()`
 returns the kernel as a callable object. It can be called like a function.
 The parameters are the kernel grid size and as optional the amount dynamic shared
 memory. This is analogous to the kernel launch configuration in CUDA that is
@@ -275,7 +275,7 @@ If the a kernel function is not declared with the `extern "C"`
 `nvcc` generates C++ symbols for kernel functions. Such kernels can be enclosed
 in a `kernels` scope in the NIDL file and subsequently bound in one step.
 As in `hostfuncs` for C++ host functions, a C++ namespace can also be
-specified in `kernels`. grCUDA the searches all functions within the scope
+specified in `kernels`. GrCUDA the searches all functions within the scope
 in this namespace.
 
 Kernel function defined with `extern "C"` can bound in a `ckernels` scope.
@@ -288,7 +288,7 @@ e.g., `increment`.
 
 ## Runtime-compilation of GPU Kernels from CUDA C/C++
 
-grCUDA can also compile GPU kernels directly from CUDA C/C++
+GrCUDA can also compile GPU kernels directly from CUDA C/C++
 source code passed as a host-string argument to
 `buildkernel(..)`. The signature of the function is:
 
@@ -339,7 +339,7 @@ print(device_array)
 ## Launching Kernels
 
 Once a kernel function is bound to a callable host-object or registered as
-a function within grCUDA, it can be launched like a function with two argument lists (for exceptions in Ruby and Java and Ruby see the examples below).
+a function within GrCUDA, it can be launched like a function with two argument lists (for exceptions in Ruby and Java and Ruby see the examples below).
 
 ```test
 kernel(num_blocks, block_size)(arg1, ..., argN)
@@ -355,7 +355,7 @@ The first argument list corresponds to the launch configuration, i.e.,
 the kernel grid (number of blocks) and the block sizes (number of
 threads per block).
 
-grCUDA currently only supports synchronous kernel launches,
+GrCUDA currently only supports synchronous kernel launches,
 i.e., there is an implicit `cudaDeviceSynchronize()` after every
 launch.
 
@@ -372,8 +372,8 @@ configured_kernel = kernel(num_blocks, block_size)
 configured_kernel(out_arr, in_ar, num_elements)
 ```
 
-grCUDA also supports 2D and 3D kernel grids that are specified
-with the `dim3` in CUDA C/C++. In grCUDA `num_blocks` and `block_size`
+GrCUDA also supports 2D and 3D kernel grids that are specified
+with the `dim3` in CUDA C/C++. In GrCUDA `num_blocks` and `block_size`
 can be integers for 1-dimensional kernels or host language sequences
 of length 1, 2, or 3 (Lists or Tuples in Python, Arrays in JavaScript
 and Ruby, and vectors in R)

--- a/docs/typemapping.md
+++ b/docs/typemapping.md
@@ -1,6 +1,6 @@
 # Type Mapping for C++
 
-grCUDA needs to interact with tree different type systems:
+GrCUDA needs to interact with tree different type systems:
 
 - The Java types of the Truffle interop protocol (`boolean`, `byte`, `short`, `int`, `long`, `float`, `double`, `String`)
   as described in [InteropLibrary](https://www.graalvm.org/truffle/javadoc/com/oracle/truffle/api/interop/InteropLibrary.html).
@@ -10,7 +10,7 @@ grCUDA needs to interact with tree different type systems:
 - C interface types from TruffleNFI (`void`, `sint8`, `uint8`, `sint16`, `uint16`, `sint32`, `uint32`, `sint64`, `uint64`,
     `float`, `double`, `pointer`, `object`, `string`).
   [NativeSimpleType.java](https://github.com/oracle/graal/blob/master/truffle/src/com.oracle.truffle.nfi.spi/src/com/oracle/truffle/nfi/spi/types/NativeSimpleType.java)
-  defines these types. grCUDA uses TruffleNFI to invoke native host functions. While TruffleNFI is designed for C APIs, the C++ types are necessary create the mangled symbols names to invoke with TruffleNFI.
+  defines these types. GrCUDA uses TruffleNFI to invoke native host functions. While TruffleNFI is designed for C APIs, the C++ types are necessary create the mangled symbols names to invoke with TruffleNFI.
 
 Types for clang/gcc under Linux (LP64)
 
@@ -44,7 +44,7 @@ void *             |  8  | Pv  | out pointer void   | pointer  | n/a
 const void *       |  8  | PKv | in pointer void    | pointer  | n/a
 const char *       |  8  | PKc | string             | string   | String
 
-(*) not supported in grCUDA or NFI
+(*) not supported in GrCUDA or NFI
 (+) does not support all values (NFI limitation)
 
 ## Synonymous NIDL types

--- a/examples/mandelbrot/README.md
+++ b/examples/mandelbrot/README.md
@@ -1,10 +1,10 @@
 # Mandelbrot Web Application with Express
 
-This example demonstrates how grCUDA can be used in a Node.js
+This example demonstrates how GrCUDA can be used in a Node.js
 web application with the Express framework.
 
 The code is described in the
-[NVIDIA Developer Blog on grCUDA](https://devblogs.nvidia.com/grcuda-a-polyglot-language-binding-for-cuda-in-graalvm/).
+[NVIDIA Developer Blog on GrCUDA](https://devblogs.nvidia.com/grcuda-a-polyglot-language-binding-for-cuda-in-graalvm/).
 For more details, see the blog.
 
 ## How to run the Example

--- a/examples/tensorrt/README.md
+++ b/examples/tensorrt/README.md
@@ -1,8 +1,8 @@
-# grCUDA and TensorRT
+# GrCUDA and TensorRT
 
 This example uses TensorFlow 1.x to train a LeNet5 model on the MNIST dataset. An inference engine is then created
 from the trained module using TensorRT through its Python API. This engine is serialized to a file.
-The engine is subsequently instantiated from a Node.js application using grCUDA.
+The engine is subsequently instantiated from a Node.js application using GrCUDA.
 
 The serialization of the frozen model to a Protobuf file is only supported in TensorFlow 1.x.
 As per Tensor-RT 7.0, its provided end-to-end examples are only working under TensorFlow 1.x.
@@ -141,7 +141,7 @@ Now, we show how to instantiate the serialized engine in a native
 C++ application (`cpp/load_and_sample.cc`) using the C++ TensorRT
 inference library.
 This is an optional step provided here only for completeness. It
-does not use grCUDA C-wrapper library `libtrt.so` nor grCUDA.
+does not use GrCUDA C-wrapper library `libtrt.so` nor GrCUDA.
 
 ```console
 $ cd cpp
@@ -202,12 +202,12 @@ output tensor: 10 elements
 
 ```
 
-## Instantiation of Inference Engine from grCUDA
+## Instantiation of Inference Engine from GrCUDA
 
-First, build that the grCUDA wrapper library `libtrt` for TensorRT.
+First, build that the GrCUDA wrapper library `libtrt` for TensorRT.
 
 ```console
-$ cd <grCUDA repo root>../tensorrt
+$ cd <GrCUDA repo root>../tensorrt
 $ mkdir build
 $ cd build
 $ cmake .. -DTENSORRT_DIR=/usr/local/TensorRT-7.0.0.11/

--- a/examples/tensorrt/tensorrt_example.js
+++ b/examples/tensorrt/tensorrt_example.js
@@ -25,7 +25,7 @@
 
 const fs = require('fs')
 
-// get grCUDA root namespace and trt namespace object
+// get GrCUDA root namespace and trt namespace object
 const cu = Polyglot.eval('grcuda', 'CU')
 const trt = Polyglot.eval('grcuda', 'CU::TRT')
 

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/ManglingTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/ManglingTest.java
@@ -80,7 +80,7 @@ public class ManglingTest {
         }
         sourceGen.extractMangledNames(stdout);
 
-        // Check grCUDA-generated mangled names with compiler output
+        // Check GrCUDA-generated mangled names with compiler output
         int idx = 0;
         for (Binding binding : bindings) {
             String expectedMangledName = sourceGen.getMangledName(idx);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -59,7 +59,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Context for the grCUDA language holds reference to CUDA runtime, a function registry and device
+ * Context for the GrCUDA language holds reference to CUDA runtime, a function registry and device
  * resources.
  */
 public final class GrCUDAContext {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDALanguage.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDALanguage.java
@@ -40,7 +40,7 @@ import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.interop.TruffleObject;
 
 /**
- * grCUDA Truffle language that exposes the GPU device and CUDA runtime to polyglot Graal languages.
+ * GrCUDA Truffle language that exposes the GPU device and CUDA runtime to polyglot Graal languages.
  */
 @TruffleLanguage.Registration(id = GrCUDALanguage.ID, name = "grcuda", version = "0.1", internal = false, contextPolicy = TruffleLanguage.ContextPolicy.SHARED)
 public final class GrCUDALanguage extends TruffleLanguage<GrCUDAContext> {

--- a/tensorrt/README.md
+++ b/tensorrt/README.md
@@ -1,14 +1,14 @@
-# grCUDA and TensorRT
+# GrCUDA and TensorRT
 
 This directory contains a wrapper library `libtrt.so` for TensorRT.
 It simplifies the use of the TensorRT inference library.
 
 ## Build libtrt
 
-Build that the grCUDA wrapper library `libtrt` for TensorRT.
+Build that the GrCUDA wrapper library `libtrt` for TensorRT.
 
 ```console
-$ cd <grCUDA repo root>../tensorrt
+$ cd <GrCUDA repo root>../tensorrt
 $ mkdir build
 $ cd build
 $ cmake .. -DTENSORRT_DIR=/usr/local/TensorRT-7.0.0.11/
@@ -75,7 +75,7 @@ prediction: 4
 destroying inference runtime...
 ```
 
-## Use libtrt in grCUDA
+## Use libtrt in GrCUDA
 
 ```bash
 GRCUDA_JAR="$GRCUDA_BUILD_DIR/mxbuild/dists/jdk1.8/grcuda.jar"


### PR DESCRIPTION
Replaced "**grCUDA**" with "**GrCUDA**" in all files (exception: variable names starting with "grCUDA", i.e. _grCUDAExecutionContext_) and filenames (actually no file or folder had grCUDA in their names).