### PR TITLE
[GrCUDA-50] option map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2021-11-15
+
+* Added read-only polyglot map to retrieve grcuda options. Retrieve it with `getoptions`. Option names and values are provided as strings. Find the full list of options in `GrCUDAOptions`.
+
 # 2021-11-04
 
 * Enabled the usage of TruffleLoggers for logging the execution of grcuda code

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/GrCUDAOptionMapTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/GrCUDAOptionMapTest.java
@@ -169,4 +169,33 @@ public class GrCUDAOptionMapTest {
             assertEquals(GrCUDAOptionMap.DEFAULT_ENABLE_MULTIGPU, Boolean.valueOf(options.getHashValue("grcuda.EnableMultiGPU").asString()));
         }
     }
+
+    @Test
+    public void testGetOptionsFunctionIterator() {
+        try (Context ctx = GrCUDATestUtil.buildTestContext().option("grcuda.ExecutionPolicy", ExecutionPolicyEnum.ASYNC.toString()).build()) {
+            // Obtain the options map;
+            Value options = ctx.eval("grcuda", "getoptions").execute();
+            // Get the iterator;
+            Value iterator = options.getHashEntriesIterator();
+            int optionCount = 0;
+            // Check that we can find a specific option key and value;
+            String optionKeyToFind = "grcuda.ExecutionPolicy";
+            String optionValueToFind = ExecutionPolicyEnum.ASYNC.toString();
+            boolean optionFound = false;
+            while (iterator.hasIteratorNextElement()) {
+                Value option = iterator.getIteratorNextElement();
+                assertEquals(2, option.getArraySize());
+                if (option.getArrayElement(0).asString().equals(optionKeyToFind)) {
+                    optionFound = true;
+                    assertEquals(optionValueToFind, option.getArrayElement(1).asString());
+                }
+                optionCount++;
+            }
+            assertTrue(optionFound);
+            assertTrue(iterator.isIterator());
+            assertFalse(iterator.hasIteratorNextElement());
+            assertEquals(options.getHashSize(), optionCount);
+        }
+    }
+
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/GrCUDAOptionMapTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/GrCUDAOptionMapTest.java
@@ -47,11 +47,9 @@ import org.graalvm.options.OptionKey;
 import org.graalvm.options.OptionValues;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
-
 
 public class GrCUDAOptionMapTest {
 
@@ -68,10 +66,10 @@ public class GrCUDAOptionMapTest {
         options.put(GrCUDAOptions.TensorRTEnabled, false);
         unparsedOptions.put(GrCUDAOptions.CuBLASLibrary, CUBLASRegistry.DEFAULT_LIBRARY);
         unparsedOptions.put(GrCUDAOptions.CuMLLibrary, CUMLRegistry.DEFAULT_LIBRARY);
-        unparsedOptions.put(GrCUDAOptions.ExecutionPolicy, GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName());
-        unparsedOptions.put(GrCUDAOptions.DependencyPolicy, GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName());
-        unparsedOptions.put(GrCUDAOptions.RetrieveNewStreamPolicy, GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
-        unparsedOptions.put(GrCUDAOptions.RetrieveParentStreamPolicy, GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.ExecutionPolicy, GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.toString());
+        unparsedOptions.put(GrCUDAOptions.DependencyPolicy, GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.toString());
+        unparsedOptions.put(GrCUDAOptions.RetrieveNewStreamPolicy, GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.toString());
+        unparsedOptions.put(GrCUDAOptions.RetrieveParentStreamPolicy, GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.toString());
         unparsedOptions.put(GrCUDAOptions.TensorRTLibrary, TensorRTRegistry.DEFAULT_LIBRARY);
 
         OptionValues optionValues = new OptionValuesMock();
@@ -82,10 +80,10 @@ public class GrCUDAOptionMapTest {
     }
 
     public void initializeNull(){
-        unparsedOptions.put(GrCUDAOptions.ExecutionPolicy, GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName());
-        unparsedOptions.put(GrCUDAOptions.DependencyPolicy, GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName());
-        unparsedOptions.put(GrCUDAOptions.RetrieveNewStreamPolicy, GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
-        unparsedOptions.put(GrCUDAOptions.RetrieveParentStreamPolicy, GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.ExecutionPolicy, GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.toString());
+        unparsedOptions.put(GrCUDAOptions.DependencyPolicy, GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.toString());
+        unparsedOptions.put(GrCUDAOptions.RetrieveNewStreamPolicy, GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.toString());
+        unparsedOptions.put(GrCUDAOptions.RetrieveParentStreamPolicy, GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.toString());
         unparsedOptions.put(GrCUDAOptions.TensorRTLibrary, null);
 
         OptionValues optionValues = new OptionValuesMock();
@@ -117,15 +115,15 @@ public class GrCUDAOptionMapTest {
 
     @Test
     public void testGetOptionsFunction() {
-        try (Context ctx = GrCUDATestUtil.buildTestContext().option("grcuda.ExecutionPolicy", ExecutionPolicyEnum.ASYNC.getName()).build()) {
+        try (Context ctx = GrCUDATestUtil.buildTestContext().option("grcuda.ExecutionPolicy", ExecutionPolicyEnum.ASYNC.toString()).build()) {
             // Obtain the options map;
             Value options = ctx.eval("grcuda", "getoptions").execute();
             // Check the we have a map;
             assertTrue(options.hasHashEntries());
-            System.out.println(options.getHashSize());
+
             // Obtain some options;
-            assertEquals(options.getHashValue("grcuda.ExecutionPolicy").asString(), ExecutionPolicyEnum.ASYNC.getName());
-            assertEquals(options.getHashValue("grcuda.EnableMultiGPU").asBoolean(), GrCUDAOptionMap.DEFAULT_ENABLE_MULTIGPU);
+            assertEquals(ExecutionPolicyEnum.ASYNC.toString(), options.getHashValue("grcuda.ExecutionPolicy").asString());
+            assertEquals(GrCUDAOptionMap.DEFAULT_ENABLE_MULTIGPU, Boolean.valueOf(options.getHashValue("grcuda.EnableMultiGPU").asString()));
         }
     }
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/cudalibraries/CUBLASTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/cudalibraries/CUBLASTest.java
@@ -55,7 +55,7 @@ public class CUBLASTest {
     public static Collection<Object[]> data() {
 
         return GrCUDATestUtil.crossProduct(Arrays.asList(new Object[][]{
-                {ExecutionPolicyEnum.SYNC.getName(), ExecutionPolicyEnum.ASYNC.getName()},
+                {ExecutionPolicyEnum.SYNC.toString(), ExecutionPolicyEnum.ASYNC.toString()},
                 {true, false},
                 {'S', 'D', 'C', 'Z'}
         }));

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/cudalibraries/CUMLTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/cudalibraries/CUMLTest.java
@@ -51,7 +51,7 @@ public class CUMLTest {
     public static Collection<Object[]> data() {
 
         return GrCUDATestUtil.crossProduct(Arrays.asList(new Object[][]{
-                        {ExecutionPolicyEnum.SYNC.getName(), ExecutionPolicyEnum.ASYNC.getName()},
+                        {ExecutionPolicyEnum.SYNC.toString(), ExecutionPolicyEnum.ASYNC.toString()},
                         {true, false},
                         {'S', 'D'}
         }));

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/functions/GrCUDAOptionMapTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/functions/GrCUDAOptionMapTest.java
@@ -1,0 +1,2 @@
+package com.nvidia.grcuda.test.functions;public class GrCUDAOptionMapTest {
+}

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/functions/GrCUDAOptionMapTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/functions/GrCUDAOptionMapTest.java
@@ -101,13 +101,13 @@ public class GrCUDAOptionMapTest {
     @Test(expected = UnknownKeyException.class)
     public void testReadUnknownKey() throws UnsupportedMessageException, UnknownKeyException {
         initializeNull();
-        optionMap.readHashValue(new OptionKey<String>("test"));
+        optionMap.readHashValue("test");
     }
 
     @Test(expected = UnsupportedMessageException.class)
     public void testReadUnsupportedMessage() throws UnsupportedMessageException, UnknownKeyException {
         initializeDefault();
-        optionMap.readHashValue("");
+        optionMap.readHashValue(null);
     }
 
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/functions/GrCUDAOptionMapTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/functions/GrCUDAOptionMapTest.java
@@ -1,2 +1,113 @@
-package com.nvidia.grcuda.test.functions;public class GrCUDAOptionMapTest {
+/*
+ * Copyright (c) 2020, 2021, NECSTLab, Politecnico di Milano. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NECSTLab nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  * Neither the name of Politecnico di Milano nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nvidia.grcuda.test.functions;
+
+import static org.junit.Assert.assertEquals;
+
+import com.nvidia.grcuda.GrCUDAOptionMap;
+import com.nvidia.grcuda.GrCUDAOptions;
+import com.nvidia.grcuda.cudalibraries.cublas.CUBLASRegistry;
+import com.nvidia.grcuda.cudalibraries.cuml.CUMLRegistry;
+import com.nvidia.grcuda.cudalibraries.tensorrt.TensorRTRegistry;
+import com.nvidia.grcuda.test.util.mock.OptionValuesMock;
+import com.oracle.truffle.api.interop.UnknownKeyException;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import org.graalvm.options.OptionKey;
+import org.graalvm.options.OptionValues;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+
+public class GrCUDAOptionMapTest {
+
+    private GrCUDAOptionMap optionMap;
+    private final HashMap<OptionKey<String>, String> unparsedOptions = new HashMap<>();
+    private final HashMap<OptionKey<Boolean>, Boolean> options = new HashMap<>();
+
+    public void initializeDefault(){
+        options.put(GrCUDAOptions.CuBLASEnabled, true);
+        options.put(GrCUDAOptions.CuMLEnabled, true);
+        options.put(GrCUDAOptions.ForceStreamAttach, GrCUDAOptionMap.DEFAULT_FORCE_STREAM_ATTACH);
+        options.put(GrCUDAOptions.InputPrefetch, false);
+        options.put(GrCUDAOptions.EnableMultiGPU, false);
+        options.put(GrCUDAOptions.TensorRTEnabled, false);
+        unparsedOptions.put(GrCUDAOptions.CuBLASLibrary, CUBLASRegistry.DEFAULT_LIBRARY);
+        unparsedOptions.put(GrCUDAOptions.CuMLLibrary, CUMLRegistry.DEFAULT_LIBRARY);
+        unparsedOptions.put(GrCUDAOptions.ExecutionPolicy, GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.DependencyPolicy, GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.RetrieveNewStreamPolicy, GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.RetrieveParentStreamPolicy, GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.TensorRTLibrary, TensorRTRegistry.DEFAULT_LIBRARY);
+
+        OptionValues optionValues = new OptionValuesMock();
+        options.forEach(optionValues::set);
+        unparsedOptions.forEach(optionValues::set);
+
+        optionMap = GrCUDAOptionMap.getInstance(optionValues);
+    }
+
+    public void initializeNull(){
+        unparsedOptions.put(GrCUDAOptions.ExecutionPolicy, GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.DependencyPolicy, GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.RetrieveNewStreamPolicy, GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.RetrieveParentStreamPolicy, GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName());
+        unparsedOptions.put(GrCUDAOptions.TensorRTLibrary, null);
+
+        OptionValues optionValues = new OptionValuesMock();
+        unparsedOptions.forEach(optionValues::set);
+
+        optionMap = GrCUDAOptionMap.getInstance(optionValues);
+    }
+
+    @Test
+    public void testGetOption(){
+        initializeDefault();
+        assertEquals(optionMap.isCuBLASEnabled(), true);
+        assertEquals(optionMap.isForceStreamAttach(), false);
+        assertEquals(optionMap.getCuBLASLibrary(), CUBLASRegistry.DEFAULT_LIBRARY);
+        assertEquals(optionMap.getDependencyPolicy(), GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY);
+    }
+
+    @Test(expected = UnknownKeyException.class)
+    public void testReadUnknownKey() throws UnsupportedMessageException, UnknownKeyException {
+        initializeNull();
+        optionMap.readHashValue(new OptionKey<String>("test"));
+    }
+
+    @Test(expected = UnsupportedMessageException.class)
+    public void testReadUnsupportedMessage() throws UnsupportedMessageException, UnknownKeyException {
+        initializeDefault();
+        optionMap.readHashValue("");
+    }
+
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/GrCUDATestUtil.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/GrCUDATestUtil.java
@@ -91,11 +91,11 @@ public class GrCUDATestUtil {
 
     public static Context createContextFromOptions(GrCUDATestOptionsStruct options) {
         return buildTestContext()
-                .option("grcuda.ExecutionPolicy", options.policy.getName())
+                .option("grcuda.ExecutionPolicy", options.policy.toString())
                 .option("grcuda.InputPrefetch", String.valueOf(options.inputPrefetch))
-                .option("grcuda.RetrieveNewStreamPolicy", options.retrieveNewStreamPolicy.getName())
-                .option("grcuda.RetrieveParentStreamPolicy", options.retrieveParentStreamPolicy.getName())
-                .option("grcuda.DependencyPolicy", options.dependencyPolicy.getName())
+                .option("grcuda.RetrieveNewStreamPolicy", options.retrieveNewStreamPolicy.toString())
+                .option("grcuda.RetrieveParentStreamPolicy", options.retrieveParentStreamPolicy.toString())
+                .option("grcuda.DependencyPolicy", options.dependencyPolicy.toString())
                 .option("grcuda.ForceStreamAttach", String.valueOf(options.forceStreamAttach))
                 .build();
     }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/OptionValuesMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/OptionValuesMock.java
@@ -39,7 +39,6 @@ import java.util.Map;
 
 public class OptionValuesMock implements OptionValues {
 
-
     private final Map<OptionKey<?>, Object> values;
     private final Map<OptionKey<?>, String> unparsedValues;
 
@@ -47,7 +46,6 @@ public class OptionValuesMock implements OptionValues {
         this.values =  new HashMap<>();
         this.unparsedValues =  new HashMap<>();
     }
-
 
     @Override
     public OptionDescriptors getDescriptors() {
@@ -73,5 +71,4 @@ public class OptionValuesMock implements OptionValues {
     public boolean hasSetOptions() {
         return OptionValues.super.hasSetOptions();
     }
-
 }

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/OptionValuesMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/OptionValuesMock.java
@@ -1,0 +1,48 @@
+package com.nvidia.grcuda.test.util.mock;
+
+import org.graalvm.options.OptionDescriptor;
+import org.graalvm.options.OptionDescriptors;
+import org.graalvm.options.OptionKey;
+import org.graalvm.options.OptionValues;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class OptionValuesMock implements OptionValues {
+
+
+    private final Map<OptionKey<?>, Object> values;
+    private final Map<OptionKey<?>, String> unparsedValues;
+
+    public OptionValuesMock() {
+        this.values =  new HashMap<>();
+        this.unparsedValues =  new HashMap<>();
+    }
+
+
+    @Override
+    public OptionDescriptors getDescriptors() {
+        return null;
+    }
+
+    @Override
+    public <T> void set(OptionKey<T> optionKey, T value) {
+        this.values.put(optionKey, value);
+    }
+
+    @Override
+    public <T> T get(OptionKey<T> optionKey) {
+        return (T) this.values.get(optionKey);
+    }
+
+    @Override
+    public boolean hasBeenSet(OptionKey<?> optionKey) {
+        return values.containsKey(optionKey) || unparsedValues.containsKey(optionKey);
+    }
+
+    @Override
+    public boolean hasSetOptions() {
+        return OptionValues.super.hasSetOptions();
+    }
+
+}

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/OptionValuesMock.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/util/mock/OptionValuesMock.java
@@ -1,6 +1,35 @@
+/*
+ * Copyright (c) 2020, 2021, NECSTLab, Politecnico di Milano. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NECSTLab nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  * Neither the name of Politecnico di Milano nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.nvidia.grcuda.test.util.mock;
 
-import org.graalvm.options.OptionDescriptor;
 import org.graalvm.options.OptionDescriptors;
 import org.graalvm.options.OptionKey;
 import org.graalvm.options.OptionValues;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -103,7 +103,7 @@ public final class GrCUDAContext {
         DependencyPolicyEnum dependencyPolicy = grCUDAOptionMap.getDependencyPolicy();
 
         // Retrieve the execution policy;
-        ExecutionPolicyEnum executionPolicy = (ExecutionPolicyEnum) grCUDAOptionMap.getExecutionPolicy();
+        ExecutionPolicyEnum executionPolicy = grCUDAOptionMap.getExecutionPolicy();
 
         // FIXME: TensorRT is currently incompatible with the async scheduler. TensorRT is supported in CUDA 11.4, and we cannot test it. 
         //  Once Nvidia adds support for it, we want to remove this limitation;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -54,14 +54,10 @@ import com.nvidia.grcuda.runtime.executioncontext.AbstractGrCUDAExecutionContext
 import com.nvidia.grcuda.runtime.executioncontext.ExecutionPolicyEnum;
 import com.nvidia.grcuda.runtime.executioncontext.GrCUDAExecutionContext;
 import com.nvidia.grcuda.runtime.executioncontext.SyncGrCUDAExecutionContext;
-import com.nvidia.grcuda.runtime.stream.RetrieveNewStreamPolicyEnum;
-import com.nvidia.grcuda.runtime.stream.RetrieveParentStreamPolicyEnum;
 import com.nvidia.grcuda.cudalibraries.tensorrt.TensorRTRegistry;
 import com.oracle.truffle.api.CallTarget;
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.TruffleLogger;
-import org.graalvm.options.OptionKey;
 
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
@@ -110,7 +106,7 @@ public final class GrCUDAContext {
         Boolean inputPrefetch = grCUDAOptionMap.isInputPrefetch();
 
         // Initialize the execution policy;
-        LOGGER.fine("using" + executionPolicy.getName() + " execution policy");
+        LOGGER.fine("using" + executionPolicy.toString() + " execution policy");
         switch (executionPolicy) {
             case SYNC:
                 this.grCUDAExecutionContext = new SyncGrCUDAExecutionContext(this, env, dependencyPolicy, inputPrefetch ? PrefetcherEnum.SYNC : PrefetcherEnum.NONE);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -63,7 +63,6 @@ import com.oracle.truffle.api.TruffleLogger;
 import org.graalvm.options.OptionKey;
 
 import java.util.ArrayList;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -101,10 +100,10 @@ public final class GrCUDAContext {
         this.grCUDAOptionMap = new GrCUDAOptionMap(env.getOptions());
 
         // Retrieve the dependency computation policy;
-        DependencyPolicyEnum dependencyPolicy = (DependencyPolicyEnum) grCUDAOptionMap.getValueRuntime(GrCUDAOptions.DependencyPolicy);
+        DependencyPolicyEnum dependencyPolicy = grCUDAOptionMap.getDependencyPolicy();
 
         // Retrieve the execution policy;
-        ExecutionPolicyEnum executionPolicy = (ExecutionPolicyEnum) grCUDAOptionMap.getValueRuntime(GrCUDAOptions.ExecutionPolicy);
+        ExecutionPolicyEnum executionPolicy = (ExecutionPolicyEnum) grCUDAOptionMap.getExecutionPolicy();
 
         // FIXME: TensorRT is currently incompatible with the async scheduler. TensorRT is supported in CUDA 11.4, and we cannot test it. 
         //  Once Nvidia adds support for it, we want to remove this limitation;
@@ -113,7 +112,7 @@ public final class GrCUDAContext {
             executionPolicy = ExecutionPolicyEnum.SYNC;
         }
 
-        Boolean inputPrefetch = (Boolean) grCUDAOptionMap.getValueRuntime(GrCUDAOptions.InputPrefetch);
+        Boolean inputPrefetch = grCUDAOptionMap.isInputPrefetch();
 
         // Initialize the execution policy;
         LOGGER.fine("using" + executionPolicy.getName() + " execution policy");
@@ -204,22 +203,6 @@ public final class GrCUDAContext {
         return uncachedMapCallTargets;
     }
 
-    public RetrieveNewStreamPolicyEnum getRetrieveNewStreamPolicy() {
-        return (RetrieveNewStreamPolicyEnum) grCUDAOptionMap.getValueRuntime(GrCUDAOptions.RetrieveNewStreamPolicy);
-    }
-    
-    public RetrieveParentStreamPolicyEnum getRetrieveParentStreamPolicyEnum() {
-        return (RetrieveParentStreamPolicyEnum) grCUDAOptionMap.getValueRuntime(GrCUDAOptions.RetrieveParentStreamPolicy);
-    }
-
-    public boolean isForceStreamAttach() {
-        return (Boolean) grCUDAOptionMap.getValueRuntime(GrCUDAOptions.ForceStreamAttach);
-    }
-
-    public boolean isEnableMultiGPU() {
-        return (Boolean) grCUDAOptionMap.getValueRuntime(GrCUDAOptions.EnableMultiGPU);
-    }
-
     /**
      * Compute the maximum number of concurrent threads that can be spawned by GrCUDA.
      * This value is usually smaller or equal than the number of logical CPU threads available on the machine.
@@ -233,6 +216,8 @@ public final class GrCUDAContext {
     public <T> T getOption(OptionKey<T> key) {
         return env.getOptions().get(key);
     }
+
+    public GrCUDAOptionMap getOptionMap(){return grCUDAOptionMap;}
 
     /**
      * Cleanup the GrCUDA context at the end of the execution;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -97,7 +97,7 @@ public final class GrCUDAContext {
     public GrCUDAContext(Env env) {
         this.env = env;
 
-        this.grCUDAOptionMap = new GrCUDAOptionMap(env.getOptions());
+        this.grCUDAOptionMap = GrCUDAOptionMap.getInstance(env.getOptions());
 
         // Retrieve the dependency computation policy;
         DependencyPolicyEnum dependencyPolicy = grCUDAOptionMap.getDependencyPolicy();

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -98,7 +98,7 @@ public final class GrCUDAContext {
 
         // FIXME: TensorRT is currently incompatible with the async scheduler. TensorRT is supported in CUDA 11.4, and we cannot test it. 
         //  Once Nvidia adds support for it, we want to remove this limitation;
-        if (this.getOptions().isTensorRTEnabled() && (executionPolicy == ExecutionPolicyEnum.ASYNC)) {
+        if (grCUDAOptionMap.isTensorRTEnabled() && (executionPolicy == ExecutionPolicyEnum.ASYNC)) {
             LOGGER.warning("TensorRT and the asynchronous scheduler are not compatible. Switching to the synchronous scheduler.");
             executionPolicy = ExecutionPolicyEnum.SYNC;
         }
@@ -129,9 +129,9 @@ public final class GrCUDAContext {
         namespace.addFunction(new BuildKernelFunction(this.grCUDAExecutionContext));
         namespace.addFunction(new GetDevicesFunction(this.grCUDAExecutionContext.getCudaRuntime()));
         namespace.addFunction(new GetDeviceFunction(this.grCUDAExecutionContext.getCudaRuntime()));
-        namespace.addFunction(new GetOptionsFunction(this.getOptions()));
+        namespace.addFunction(new GetOptionsFunction(grCUDAOptionMap));
         this.grCUDAExecutionContext.getCudaRuntime().registerCUDAFunctions(namespace);
-        if (this.getOptions().isCuMLEnabled()) {
+        if (grCUDAOptionMap.isCuMLEnabled()) {
             if (this.getCUDARuntime().isArchitectureIsPascalOrNewer()) {
                 Namespace ml = new Namespace(CUMLRegistry.NAMESPACE);
                 namespace.addNamespace(ml);
@@ -140,12 +140,12 @@ public final class GrCUDAContext {
                 LOGGER.warning("cuML is supported only on GPUs with compute capability >= 6.0 (Pascal and newer). It cannot be enabled.");
             }
         }
-        if (this.getOptions().isCuBLASEnabled()) {
+        if (grCUDAOptionMap.isCuBLASEnabled()) {
                 Namespace blas = new Namespace(CUBLASRegistry.NAMESPACE);
                 namespace.addNamespace(blas);
                 new CUBLASRegistry(this).registerCUBLASFunctions(blas);
         }
-        if (this.getOptions().isTensorRTEnabled()) {
+        if (grCUDAOptionMap.isTensorRTEnabled()) {
             Namespace trt = new Namespace(TensorRTRegistry.NAMESPACE);
             namespace.addNamespace(trt);
             new TensorRTRegistry(this).registerTensorRTFunctions(trt);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -72,12 +72,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class GrCUDAContext {
 
-    public static final ExecutionPolicyEnum DEFAULT_EXECUTION_POLICY = ExecutionPolicyEnum.ASYNC;
-    public static final DependencyPolicyEnum DEFAULT_DEPENDENCY_POLICY = DependencyPolicyEnum.NO_CONST;
-    public static final RetrieveNewStreamPolicyEnum DEFAULT_RETRIEVE_STREAM_POLICY = RetrieveNewStreamPolicyEnum.FIFO;
-    public static final RetrieveParentStreamPolicyEnum DEFAULT_PARENT_STREAM_POLICY = RetrieveParentStreamPolicyEnum.SAME_AS_PARENT;
-    public static final boolean DEFAULT_FORCE_STREAM_ATTACH = false;
-
     private static final String ROOT_NAMESPACE = "CU";
 
     private static final TruffleLogger LOGGER = TruffleLogger.getLogger(GrCUDALanguage.ID, "com.nvidia.grcuda.GrCUDAContext");

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -66,7 +66,8 @@ public class GrCUDAOptionMap implements TruffleObject {
         // how streams are obtained from parent computations;
         optionKeyValueMap.replace(GrCUDAOptions.RetrieveParentStreamPolicy, parseParentStreamPolicy(options.get(GrCUDAOptions.RetrieveParentStreamPolicy)));
         // dependency computation policy;
-        DependencyPolicyEnum dependencyPolicy = (DependencyPolicyEnum) optionKeyValueMap.replace(GrCUDAOptions.DependencyPolicy, parseDependencyPolicy(options.get(GrCUDAOptions.DependencyPolicy)));
+        optionKeyValueMap.replace(GrCUDAOptions.DependencyPolicy, parseDependencyPolicy(options.get(GrCUDAOptions.DependencyPolicy)));
+        DependencyPolicyEnum dependencyPolicy = getDependencyPolicy();
         LOGGER.fine("using " + dependencyPolicy.getName() + " dependency policy");
         // execution policy;
         optionKeyValueMap.replace(GrCUDAOptions.ExecutionPolicy, parseExecutionPolicy(options.get(GrCUDAOptions.ExecutionPolicy)));

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -35,25 +35,29 @@ import com.nvidia.grcuda.runtime.executioncontext.ExecutionPolicyEnum;
 import com.nvidia.grcuda.runtime.stream.RetrieveNewStreamPolicyEnum;
 import com.nvidia.grcuda.runtime.stream.RetrieveParentStreamPolicyEnum;
 import com.oracle.truffle.api.TruffleLogger;
+import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import org.graalvm.options.OptionDescriptor;
 import org.graalvm.options.OptionKey;
 import org.graalvm.options.OptionValues;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
+@ExportLibrary(InteropLibrary.class)
 public class GrCUDAOptionMap implements TruffleObject {
 
     private HashMap<OptionKey<?>, Object> optionKeyValueMap;
     private static final TruffleLogger LOGGER = TruffleLogger.getLogger(GrCUDALanguage.ID, "com.nvidia.grcuda.GrCUDAContext");
 
-    public GrCUDAOptionMap(){ optionKeyValueMap = new HashMap<>();}
-
     public GrCUDAOptionMap(OptionValues options) {
-        this();
-
-        List<OptionKey<?>> allOptions = GrCUDAOptions.getAll();
+        optionKeyValueMap = new HashMap<>();
+        List<OptionKey<?>> allOptions = new ArrayList<>();
+        options.getDescriptors().forEach(o -> allOptions.add(o.getKey()));
 
         allOptions.forEach(i -> optionKeyValueMap.put(i, options.get(i)));
         // stream retrieval policy;
@@ -67,9 +71,19 @@ public class GrCUDAOptionMap implements TruffleObject {
         optionKeyValueMap.replace(GrCUDAOptions.ExecutionPolicy, parseExecutionPolicy(options.get(GrCUDAOptions.ExecutionPolicy)));
     }
 
-    public HashMap<OptionKey<?>, Object> getAllRuntime(){return new HashMap<>(optionKeyValueMap);}
+    public HashMap<OptionKey<?>, Object> getOptions(){
+        return optionKeyValueMap;
+    }
 
-    public Object getValueRuntime(OptionKey key){
+    @ExportMessage
+    public Object hasHashEntries(HashMap<OptionKey<?>, Object> map){
+        //TODO: any check?
+        return true;
+    }
+
+    @ExportMessage
+    public Object readHashValue(HashMap<OptionKey<?>, Object> map, OptionKey<?> key){
+        //TODO: any check?
         return optionKeyValueMap.get(key);
     }
 
@@ -108,4 +122,57 @@ public class GrCUDAOptionMap implements TruffleObject {
             return GrCUDAContext.DEFAULT_PARENT_STREAM_POLICY;
         }
     }
+
+    public Boolean isCuBLASEnabled(){
+        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.CuBLASEnabled);
+    }
+
+    public String getCuBLASLibrary(){
+        return (String) optionKeyValueMap.get(GrCUDAOptions.CuBLASLibrary);
+    }
+
+    public Boolean isCuMLEnabled(){
+        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.CuMLEnabled);
+    }
+
+    public String getCuMLLibrary(){
+        return (String) optionKeyValueMap.get(GrCUDAOptions.CuMLLibrary);
+    }
+
+    public ExecutionPolicyEnum getExecutionPolicy(){
+        return (ExecutionPolicyEnum) optionKeyValueMap.get(GrCUDAOptions.ExecutionPolicy);
+    }
+
+    public DependencyPolicyEnum getDependencyPolicy(){
+        return (DependencyPolicyEnum) optionKeyValueMap.get(GrCUDAOptions.DependencyPolicy);
+    }
+
+    public RetrieveNewStreamPolicyEnum getRetrieveNewStreamPolicy(){
+        return (RetrieveNewStreamPolicyEnum) optionKeyValueMap.get(GrCUDAOptions.RetrieveNewStreamPolicy);
+    }
+
+    public RetrieveParentStreamPolicyEnum getRetrieveParentStreamPolicy(){
+        return (RetrieveParentStreamPolicyEnum) optionKeyValueMap.get(GrCUDAOptions.RetrieveParentStreamPolicy);
+    }
+
+    public Boolean isForceStreamAttach(){
+        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.ForceStreamAttach);
+    }
+
+    public Boolean isInputPrefetch(){
+        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.InputPrefetch);
+    }
+
+    public Boolean isEnableMultiGPU(){
+        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.EnableMultiGPU);
+    }
+
+    public Boolean isTensorRTEnabled(){
+        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.TensorRTEnabled);
+    }
+
+    public String getTensorRTLibrary(){
+        return (String) optionKeyValueMap.get(GrCUDAOptions.TensorRTLibrary);
+    }
+
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -52,10 +52,16 @@ import java.util.Objects;
 @ExportLibrary(InteropLibrary.class)
 public class GrCUDAOptionMap implements TruffleObject {
 
-    private static GrCUDAOptionMap instance;
+    private static GrCUDAOptionMap instance = null;
 
     private HashMap<OptionKey<?>, Object> optionKeyValueMap;
     private static final TruffleLogger LOGGER = TruffleLogger.getLogger(GrCUDALanguage.ID, "com.nvidia.grcuda.GrCUDAContext");
+
+    public static final ExecutionPolicyEnum DEFAULT_EXECUTION_POLICY = ExecutionPolicyEnum.ASYNC;
+    public static final DependencyPolicyEnum DEFAULT_DEPENDENCY_POLICY = DependencyPolicyEnum.NO_CONST;
+    public static final RetrieveNewStreamPolicyEnum DEFAULT_RETRIEVE_STREAM_POLICY = RetrieveNewStreamPolicyEnum.FIFO;
+    public static final RetrieveParentStreamPolicyEnum DEFAULT_PARENT_STREAM_POLICY = RetrieveParentStreamPolicyEnum.SAME_AS_PARENT;
+    public static final boolean DEFAULT_FORCE_STREAM_ATTACH = false;
 
     private GrCUDAOptionMap(OptionValues options) {
         optionKeyValueMap = new HashMap<>();
@@ -76,7 +82,7 @@ public class GrCUDAOptionMap implements TruffleObject {
     }
 
     public static GrCUDAOptionMap getInstance(OptionValues options){
-        instance = new GrCUDAOptionMap(options);
+        if (instance == null) instance = new GrCUDAOptionMap(options);
         return instance;
     }
 
@@ -122,8 +128,8 @@ public class GrCUDAOptionMap implements TruffleObject {
         if (policyString.equals(ExecutionPolicyEnum.SYNC.getName())) return ExecutionPolicyEnum.SYNC;
         else if (policyString.equals(ExecutionPolicyEnum.ASYNC.getName())) return ExecutionPolicyEnum.ASYNC;
         else {
-            LOGGER.warning("unknown execution policy=" + policyString + "; using default=" + GrCUDAContext.DEFAULT_EXECUTION_POLICY);
-            return GrCUDAContext.DEFAULT_EXECUTION_POLICY;
+            LOGGER.warning("unknown execution policy=" + policyString + "; using default=" + DEFAULT_EXECUTION_POLICY);
+            return DEFAULT_EXECUTION_POLICY;
         }
     }
 
@@ -131,8 +137,8 @@ public class GrCUDAOptionMap implements TruffleObject {
         if (policyString.equals(DependencyPolicyEnum.WITH_CONST.getName())) return DependencyPolicyEnum.WITH_CONST;
         else if (policyString.equals(DependencyPolicyEnum.NO_CONST.getName())) return DependencyPolicyEnum.NO_CONST;
         else {
-            LOGGER.warning("Warning: unknown dependency policy=" + policyString + "; using default=" + GrCUDAContext.DEFAULT_DEPENDENCY_POLICY);
-            return GrCUDAContext.DEFAULT_DEPENDENCY_POLICY;
+            LOGGER.warning("Warning: unknown dependency policy=" + policyString + "; using default=" + DEFAULT_DEPENDENCY_POLICY);
+            return DEFAULT_DEPENDENCY_POLICY;
         }
     }
 
@@ -140,8 +146,8 @@ public class GrCUDAOptionMap implements TruffleObject {
         if (policyString.equals(RetrieveNewStreamPolicyEnum.FIFO.getName())) return RetrieveNewStreamPolicyEnum.FIFO;
         else if (policyString.equals(RetrieveNewStreamPolicyEnum.ALWAYS_NEW.getName())) return RetrieveNewStreamPolicyEnum.ALWAYS_NEW;
         else {
-            LOGGER.warning("Warning: unknown new stream retrieval policy=" + policyString + "; using default=" + GrCUDAContext.DEFAULT_RETRIEVE_STREAM_POLICY);
-            return GrCUDAContext.DEFAULT_RETRIEVE_STREAM_POLICY;
+            LOGGER.warning("Warning: unknown new stream retrieval policy=" + policyString + "; using default=" + DEFAULT_RETRIEVE_STREAM_POLICY);
+            return DEFAULT_RETRIEVE_STREAM_POLICY;
         }
     }
 
@@ -149,8 +155,8 @@ public class GrCUDAOptionMap implements TruffleObject {
         if (Objects.equals(policyString, RetrieveParentStreamPolicyEnum.DISJOINT.getName())) return RetrieveParentStreamPolicyEnum.DISJOINT;
         else if (Objects.equals(policyString, RetrieveParentStreamPolicyEnum.SAME_AS_PARENT.getName())) return RetrieveParentStreamPolicyEnum.SAME_AS_PARENT;
         else {
-            LOGGER.warning("Warning: unknown parent stream retrieval policy=" + policyString + "; using default=" + GrCUDAContext.DEFAULT_PARENT_STREAM_POLICY);
-            return GrCUDAContext.DEFAULT_PARENT_STREAM_POLICY;
+            LOGGER.warning("Warning: unknown parent stream retrieval policy=" + policyString + "; using default=" + DEFAULT_PARENT_STREAM_POLICY);
+            return DEFAULT_PARENT_STREAM_POLICY;
         }
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -54,7 +54,7 @@ public class GrCUDAOptionMap implements TruffleObject {
 
     private static GrCUDAOptionMap instance = null;
 
-    private HashMap<OptionKey<?>, Object> optionKeyValueMap;
+    private final HashMap<String, Object> optionsMap;
     private static final TruffleLogger LOGGER = TruffleLogger.getLogger(GrCUDALanguage.ID, "com.nvidia.grcuda.GrCUDAContext");
 
     public static final ExecutionPolicyEnum DEFAULT_EXECUTION_POLICY = ExecutionPolicyEnum.ASYNC;
@@ -62,23 +62,26 @@ public class GrCUDAOptionMap implements TruffleObject {
     public static final RetrieveNewStreamPolicyEnum DEFAULT_RETRIEVE_STREAM_POLICY = RetrieveNewStreamPolicyEnum.FIFO;
     public static final RetrieveParentStreamPolicyEnum DEFAULT_PARENT_STREAM_POLICY = RetrieveParentStreamPolicyEnum.SAME_AS_PARENT;
     public static final boolean DEFAULT_FORCE_STREAM_ATTACH = false;
+    public static final boolean DEFAULT_INPUT_PREFETCH = false;
+    public static final boolean DEFAULT_ENABLE_MULTIGPU = false;
+    public static final boolean DEFAULT_TENSORRT_ENABLED = false;
 
     private GrCUDAOptionMap(OptionValues options) {
-        optionKeyValueMap = new HashMap<>();
+        optionsMap = new HashMap<>();
         List<OptionKey<?>> allOptions = new ArrayList<>();
         options.getDescriptors().forEach(o -> allOptions.add(o.getKey()));
 
-        allOptions.forEach(i -> optionKeyValueMap.put(i, options.get(i)));
-        // stream retrieval policy;
-        optionKeyValueMap.replace(GrCUDAOptions.RetrieveNewStreamPolicy, parseRetrieveStreamPolicy(options.get(GrCUDAOptions.RetrieveNewStreamPolicy)));
-        // how streams are obtained from parent computations;
-        optionKeyValueMap.replace(GrCUDAOptions.RetrieveParentStreamPolicy, parseParentStreamPolicy(options.get(GrCUDAOptions.RetrieveParentStreamPolicy)));
-        // dependency computation policy;
-        optionKeyValueMap.replace(GrCUDAOptions.DependencyPolicy, parseDependencyPolicy(options.get(GrCUDAOptions.DependencyPolicy)));
+        allOptions.forEach(i -> optionsMap.put(i.toString(), options.get(i)));
+        // Stream retrieval policy;
+        optionsMap.replace(GrCUDAOptions.RetrieveNewStreamPolicy.toString(), parseRetrieveStreamPolicy(options.get(GrCUDAOptions.RetrieveNewStreamPolicy)));
+        // How streams are obtained from parent computations;
+        optionsMap.replace(GrCUDAOptions.RetrieveParentStreamPolicy.toString(), parseParentStreamPolicy(options.get(GrCUDAOptions.RetrieveParentStreamPolicy)));
+        // Dependency computation policy;
+        optionsMap.replace(GrCUDAOptions.DependencyPolicy.toString(), parseDependencyPolicy(options.get(GrCUDAOptions.DependencyPolicy)));
         DependencyPolicyEnum dependencyPolicy = getDependencyPolicy();
         LOGGER.fine("using " + dependencyPolicy.getName() + " dependency policy");
-        // execution policy;
-        optionKeyValueMap.replace(GrCUDAOptions.ExecutionPolicy, parseExecutionPolicy(options.get(GrCUDAOptions.ExecutionPolicy)));
+        // Execution policy;
+        optionsMap.replace(GrCUDAOptions.ExecutionPolicy.toString(), parseExecutionPolicy(options.get(GrCUDAOptions.ExecutionPolicy)));
     }
 
     public static GrCUDAOptionMap getInstance(OptionValues options){
@@ -86,46 +89,9 @@ public class GrCUDAOptionMap implements TruffleObject {
         return instance;
     }
 
-    public static GrCUDAOptionMap getInstance(){
-        return instance;
-    }
-
-    //enforces immutability
-    public HashMap<OptionKey<?>, Object> getOptions(){
-        return new HashMap<>(optionKeyValueMap);
-    }
-
-    @ExportMessage
-    public final boolean hasHashEntries(){
-        return true;
-    }
-
-    @ExportMessage
-    public final Object readHashValue(Object key) throws UnknownKeyException, UnsupportedMessageException {
-        Object value;
-        if (key instanceof String){
-            value = getValueByKeyName((String) key);
-        }
-        else {
-            throw UnsupportedMessageException.create();
-        }
-        if (value == null) throw UnknownKeyException.create(key);
-        return value.toString();
-    }
-
-    @ExportMessage
-    final long getHashSize() throws UnsupportedMessageException { return optionKeyValueMap.size(); }
-
-    @ExportMessage
-    final boolean isHashEntryReadable(Object key) {
-        return key instanceof String && getValueByKeyName((String) key) != null;
-    }
-
-    @ExportMessage
-    final Object getHashEntriesIterator() throws UnsupportedMessageException {  //TODO new map keys and values to string
-        HashMap<String, String> entries = new HashMap<>();
-        optionKeyValueMap.forEach((key, value) -> entries.put(key.getName(), value.toString()));
-        return entries.entrySet().iterator();
+    // Enforces immutability;
+    public HashMap<String, Object> getOptions(){
+        return new HashMap<>(optionsMap);
     }
 
     private static ExecutionPolicyEnum parseExecutionPolicy(String policyString) {
@@ -165,60 +131,91 @@ public class GrCUDAOptionMap implements TruffleObject {
     }
 
     public Boolean isCuBLASEnabled(){
-        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.CuBLASEnabled);
+        return (Boolean) optionsMap.get(GrCUDAOptions.CuBLASEnabled.toString());
     }
 
     public String getCuBLASLibrary(){
-        return (String) optionKeyValueMap.get(GrCUDAOptions.CuBLASLibrary);
+        return (String) optionsMap.get(GrCUDAOptions.CuBLASLibrary.toString());
     }
 
     public Boolean isCuMLEnabled(){
-        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.CuMLEnabled);
+        return (Boolean) optionsMap.get(GrCUDAOptions.CuMLEnabled.toString());
     }
 
     public String getCuMLLibrary(){
-        return (String) optionKeyValueMap.get(GrCUDAOptions.CuMLLibrary);
+        return (String) optionsMap.get(GrCUDAOptions.CuMLLibrary.toString());
     }
 
     public ExecutionPolicyEnum getExecutionPolicy(){
-        return (ExecutionPolicyEnum) optionKeyValueMap.get(GrCUDAOptions.ExecutionPolicy);
+        return (ExecutionPolicyEnum) optionsMap.get(GrCUDAOptions.ExecutionPolicy.toString());
     }
 
     public DependencyPolicyEnum getDependencyPolicy(){
-        return (DependencyPolicyEnum) optionKeyValueMap.get(GrCUDAOptions.DependencyPolicy);
+        return (DependencyPolicyEnum) optionsMap.get(GrCUDAOptions.DependencyPolicy.toString());
     }
 
     public RetrieveNewStreamPolicyEnum getRetrieveNewStreamPolicy(){
-        return (RetrieveNewStreamPolicyEnum) optionKeyValueMap.get(GrCUDAOptions.RetrieveNewStreamPolicy);
+        return (RetrieveNewStreamPolicyEnum) optionsMap.get(GrCUDAOptions.RetrieveNewStreamPolicy.toString());
     }
 
     public RetrieveParentStreamPolicyEnum getRetrieveParentStreamPolicy(){
-        return (RetrieveParentStreamPolicyEnum) optionKeyValueMap.get(GrCUDAOptions.RetrieveParentStreamPolicy);
+        return (RetrieveParentStreamPolicyEnum) optionsMap.get(GrCUDAOptions.RetrieveParentStreamPolicy.toString());
     }
 
     public Boolean isForceStreamAttach(){
-        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.ForceStreamAttach);
+        return (Boolean) optionsMap.get(GrCUDAOptions.ForceStreamAttach.toString());
     }
 
     public Boolean isInputPrefetch(){
-        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.InputPrefetch);
+        return (Boolean) optionsMap.get(GrCUDAOptions.InputPrefetch.toString());
     }
 
     public Boolean isEnableMultiGPU(){
-        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.EnableMultiGPU);
+        return (Boolean) optionsMap.get(GrCUDAOptions.EnableMultiGPU.toString());
     }
 
     public Boolean isTensorRTEnabled(){
-        return (Boolean) optionKeyValueMap.get(GrCUDAOptions.TensorRTEnabled);
+        return (Boolean) optionsMap.get(GrCUDAOptions.TensorRTEnabled.toString());
     }
 
     public String getTensorRTLibrary(){
-        return (String) optionKeyValueMap.get(GrCUDAOptions.TensorRTLibrary);
+        return (String) optionsMap.get(GrCUDAOptions.TensorRTLibrary.toString());
     }
 
-    private Object getValueByKeyName(String string){
-        for ( OptionKey<?> entry : optionKeyValueMap.keySet())
-            if (Objects.equals(entry.getName(), string)) return optionKeyValueMap.get(entry);
-        return null;
+    // Implement InteropLibrary;
+
+    @ExportMessage
+    public final boolean hasHashEntries(){
+        return true;
+    }
+
+    @ExportMessage
+    public final Object readHashValue(Object key) throws UnknownKeyException, UnsupportedMessageException {
+        Object value;
+        if (key instanceof String){
+            value = this.optionsMap.get(key.toString());
+        }
+        else {
+            throw UnsupportedMessageException.create();
+        }
+        if (value == null) throw UnknownKeyException.create(key);
+        return value.toString();
+    }
+
+    @ExportMessage
+    final long getHashSize() throws UnsupportedMessageException {
+        return optionsMap.size();
+    }
+
+    @ExportMessage
+    final boolean isHashEntryReadable(Object key) {
+        return key instanceof String && this.optionsMap.containsKey(key);
+    }
+
+    @ExportMessage
+    final Object getHashEntriesIterator() throws UnsupportedMessageException {
+        HashMap<String, String> entries = new HashMap<>();
+        optionsMap.forEach((key, value) -> entries.put(key, value.toString()));
+        return entries.entrySet().iterator();
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -109,7 +109,7 @@ public class GrCUDAOptionMap implements TruffleObject {
         else {
             throw UnsupportedMessageException.create();
         }
-        if (value == null) throw UnknownKeyException.create(key, new Throwable());
+        if (value == null) throw UnknownKeyException.create(key);
         return value;
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -276,8 +276,8 @@ public class GrCUDAOptionMap implements TruffleObject {
     @ExportLibrary(InteropLibrary.class)
     public static class GrCUDAOptionTuple implements TruffleObject {
 
-        private final int size = 2;
-        private final String[] entry = new String[size];
+        private final int SIZE = 2;
+        private final String[] entry = new String[SIZE];
 
         public GrCUDAOptionTuple(String key, String value) {
             entry[0] = key;
@@ -296,13 +296,17 @@ public class GrCUDAOptionMap implements TruffleObject {
 
         @ExportMessage
         public final Object readArrayElement(long index) throws InvalidArrayIndexException {
-            if (index == 0 || index == 1) return entry[(int)index];
-            throw InvalidArrayIndexException.create(index);
+            if (index == 0 || index == 1) {
+                return entry[(int)index];
+            }
+            else {
+                throw InvalidArrayIndexException.create(index);
+            }
         }
 
         @ExportMessage
         public final long getArraySize() {
-            return size;
+            return SIZE;
         }
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -30,8 +30,41 @@
  */
 package com.nvidia.grcuda;
 
+import com.nvidia.grcuda.runtime.computation.dependency.DependencyPolicyEnum;
+import com.nvidia.grcuda.runtime.executioncontext.ExecutionPolicyEnum;
 import com.oracle.truffle.api.interop.TruffleObject;
+import org.graalvm.options.OptionKey;
+import org.graalvm.options.OptionValues;
+
+import java.util.HashMap;
 
 public class GrCUDAOptionMap implements TruffleObject {
 
+    private HashMap<OptionKey, Object> optionTypeKeyMap = new HashMap<>();
+
+
+    public GrCUDAOptionMap(OptionValues options) {
+
+        // Retrieve if we should force array stream attachment;
+        optionTypeKeyMap.put(GrCUDAOptions.ForceStreamAttach,options.get(GrCUDAOptions.ForceStreamAttach));
+
+        // Retrieve if we should prefetch input data to GPU;
+        optionTypeKeyMap.put(GrCUDAOptions.InputPrefetch,options.get(GrCUDAOptions.InputPrefetch));
+
+        // See if we allow the use of multiple GPUs in the system;
+        optionTypeKeyMap.put(GrCUDAOptions.EnableMultiGPU,options.get(GrCUDAOptions.EnableMultiGPU));
+
+        // Retrieve the stream retrieval policy;
+        optionTypeKeyMap.put(GrCUDAOptions.RetrieveNewStreamPolicy,options.get(GrCUDAOptions.RetrieveNewStreamPolicy));
+
+        // Retrieve how streams are obtained from parent computations;
+        optionTypeKeyMap.put(GrCUDAOptions.RetrieveParentStreamPolicy,options.get(GrCUDAOptions.RetrieveParentStreamPolicy));
+
+        // Retrieve the dependency computation policy;
+        optionTypeKeyMap.put(GrCUDAOptions.DependencyPolicy,options.get(GrCUDAOptions.DependencyPolicy));
+
+        // Retrieve the execution policy;
+        optionTypeKeyMap.put(GrCUDAOptions.ExecutionPolicy,options.get(GrCUDAOptions.ExecutionPolicy));
+
+    }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -52,10 +52,12 @@ import java.util.Objects;
 @ExportLibrary(InteropLibrary.class)
 public class GrCUDAOptionMap implements TruffleObject {
 
+    private static GrCUDAOptionMap instance;
+
     private HashMap<OptionKey<?>, Object> optionKeyValueMap;
     private static final TruffleLogger LOGGER = TruffleLogger.getLogger(GrCUDALanguage.ID, "com.nvidia.grcuda.GrCUDAContext");
 
-    public GrCUDAOptionMap(OptionValues options) {
+    private GrCUDAOptionMap(OptionValues options) {
         optionKeyValueMap = new HashMap<>();
         List<OptionKey<?>> allOptions = new ArrayList<>();
         options.getDescriptors().forEach(o -> allOptions.add(o.getKey()));
@@ -73,8 +75,18 @@ public class GrCUDAOptionMap implements TruffleObject {
         optionKeyValueMap.replace(GrCUDAOptions.ExecutionPolicy, parseExecutionPolicy(options.get(GrCUDAOptions.ExecutionPolicy)));
     }
 
+    public static GrCUDAOptionMap getInstance(OptionValues options){
+        instance = new GrCUDAOptionMap(options);
+        return instance;
+    }
+
+    public static GrCUDAOptionMap getInstance(){
+        return instance;
+    }
+
+    //enforces immutability
     public HashMap<OptionKey<?>, Object> getOptions(){
-        return optionKeyValueMap;
+        return new HashMap<>(optionKeyValueMap);
     }
 
     @ExportMessage

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptionMap.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, 2021, NECSTLab, Politecnico di Milano. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NECSTLab nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  * Neither the name of Politecnico di Milano nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nvidia.grcuda;
+
+import com.oracle.truffle.api.interop.TruffleObject;
+
+public class GrCUDAOptionMap implements TruffleObject {
+
+}

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
@@ -60,16 +60,16 @@ public final class GrCUDAOptions {
     public static final OptionKey<String> CuMLLibrary = new OptionKey<>(CUMLRegistry.DEFAULT_LIBRARY);
 
     @Option(category = OptionCategory.USER, help = "Choose the scheduling policy of GrCUDA computations", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> ExecutionPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName());
+    public static final OptionKey<String> ExecutionPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.toString());
 
     @Option(category = OptionCategory.USER, help = "Choose how data dependencies between GrCUDA computations are computed", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> DependencyPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName());
+    public static final OptionKey<String> DependencyPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.toString());
 
     @Option(category = OptionCategory.USER, help = "Choose how streams for new GrCUDA computations are created", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> RetrieveNewStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
+    public static final OptionKey<String> RetrieveNewStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.toString());
 
     @Option(category = OptionCategory.USER, help = "Choose how streams for new GrCUDA computations are obtained from parent computations", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> RetrieveParentStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName());
+    public static final OptionKey<String> RetrieveParentStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.toString());
 
     @Option(category = OptionCategory.USER, help = "Force the use of array stream attaching even when not required (e.g. post-Pascal GPUs)", stability = OptionStability.EXPERIMENTAL) //
     public static final OptionKey<Boolean> ForceStreamAttach = new OptionKey<>(GrCUDAOptionMap.DEFAULT_FORCE_STREAM_ATTACH);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
@@ -44,52 +44,46 @@ import com.nvidia.grcuda.cudalibraries.cuml.CUMLRegistry;
 import com.nvidia.grcuda.cudalibraries.tensorrt.TensorRTRegistry;
 import com.oracle.truffle.api.Option;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Option.Group(GrCUDALanguage.ID)
 public final class GrCUDAOptions {
-    private GrCUDAOptions() {
-        // no instances
-    }
 
     @Option(category = OptionCategory.USER, help = "Enable cuBLAS support.", stability = OptionStability.STABLE) //
-    public static final OptionKey<Boolean> CuBLASEnabled = new OptionKey<>(true, "CuBLASEnabled");
+    public static final OptionKey<Boolean> CuBLASEnabled = new OptionKey<>(true);
 
     @Option(category = OptionCategory.USER, help = "Set the location of the cublas library.", stability = OptionStability.STABLE) //
-    public static final OptionKey<String> CuBLASLibrary = new OptionKey<>(CUBLASRegistry.DEFAULT_LIBRARY, "CuBLASLibrary");
+    public static final OptionKey<String> CuBLASLibrary = new OptionKey<>(CUBLASRegistry.DEFAULT_LIBRARY);
 
     @Option(category = OptionCategory.USER, help = "Enable cuML support.", stability = OptionStability.STABLE) //
-    public static final OptionKey<Boolean> CuMLEnabled = new OptionKey<>(true, "CuMLEnabled");
+    public static final OptionKey<Boolean> CuMLEnabled = new OptionKey<>(true);
 
     @Option(category = OptionCategory.USER, help = "Set the location of the cuml library.", stability = OptionStability.STABLE) //
-    public static final OptionKey<String> CuMLLibrary = new OptionKey<>(CUMLRegistry.DEFAULT_LIBRARY, "CuMLLibrary");
+    public static final OptionKey<String> CuMLLibrary = new OptionKey<>(CUMLRegistry.DEFAULT_LIBRARY);
 
     @Option(category = OptionCategory.USER, help = "Choose the scheduling policy of GrCUDA computations", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> ExecutionPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName(), "ExecutionPolicy");
+    public static final OptionKey<String> ExecutionPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName());
 
     @Option(category = OptionCategory.USER, help = "Choose how data dependencies between GrCUDA computations are computed", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> DependencyPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName(), "DependencyPolicy");
+    public static final OptionKey<String> DependencyPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName());
 
     @Option(category = OptionCategory.USER, help = "Choose how streams for new GrCUDA computations are created", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> RetrieveNewStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName(), "RetrieveNewStreamPolicy");
+    public static final OptionKey<String> RetrieveNewStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
 
     @Option(category = OptionCategory.USER, help = "Choose how streams for new GrCUDA computations are obtained from parent computations", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> RetrieveParentStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName(), "RetrieveParentStreamPolicy");
+    public static final OptionKey<String> RetrieveParentStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName());
 
     @Option(category = OptionCategory.USER, help = "Force the use of array stream attaching even when not required (e.g. post-Pascal GPUs)", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<Boolean> ForceStreamAttach = new OptionKey<>(false, "ForceStreamAttach");
+    public static final OptionKey<Boolean> ForceStreamAttach = new OptionKey<>(GrCUDAOptionMap.DEFAULT_FORCE_STREAM_ATTACH);
 
     @Option(category = OptionCategory.USER, help = "Always prefetch input arrays to GPU if possible (e.g. post-Pascal GPUs)", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<Boolean> InputPrefetch = new OptionKey<>(false, "InputPrefetch");
+    public static final OptionKey<Boolean> InputPrefetch = new OptionKey<>(GrCUDAOptionMap.DEFAULT_INPUT_PREFETCH);
 
     @Option(category = OptionCategory.USER, help = "Enable the option to set the current GPU in use", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<Boolean> EnableMultiGPU = new OptionKey<>(false, "EnableMultiGPU");
+    public static final OptionKey<Boolean> EnableMultiGPU = new OptionKey<>(GrCUDAOptionMap.DEFAULT_ENABLE_MULTIGPU);
 
     @Option(category = OptionCategory.USER, help = "Enable TensorRT support.", stability = OptionStability.STABLE) //
-    public static final OptionKey<Boolean> TensorRTEnabled = new OptionKey<>(false, "TensorRTEnabled");
+    public static final OptionKey<Boolean> TensorRTEnabled = new OptionKey<>(GrCUDAOptionMap.DEFAULT_TENSORRT_ENABLED);
 
     @Option(category = OptionCategory.USER, help = "Set the location of the TensorRT library.", stability = OptionStability.STABLE) //
-    public static final OptionKey<String> TensorRTLibrary = new OptionKey<>(TensorRTRegistry.DEFAULT_LIBRARY, "TensorRTLibrary");
+    public static final OptionKey<String> TensorRTLibrary = new OptionKey<>(TensorRTRegistry.DEFAULT_LIBRARY);
 
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
@@ -54,42 +54,42 @@ public final class GrCUDAOptions {
     }
 
     @Option(category = OptionCategory.USER, help = "Enable cuBLAS support.", stability = OptionStability.STABLE) //
-    public static final OptionKey<Boolean> CuBLASEnabled = new OptionKey<>(true);
+    public static final OptionKey<Boolean> CuBLASEnabled = new OptionKey<>(true, "CuBLASEnabled");
 
     @Option(category = OptionCategory.USER, help = "Set the location of the cublas library.", stability = OptionStability.STABLE) //
-    public static final OptionKey<String> CuBLASLibrary = new OptionKey<>(CUBLASRegistry.DEFAULT_LIBRARY);
+    public static final OptionKey<String> CuBLASLibrary = new OptionKey<>(CUBLASRegistry.DEFAULT_LIBRARY, "CuBLASLibrary");
 
     @Option(category = OptionCategory.USER, help = "Enable cuML support.", stability = OptionStability.STABLE) //
-    public static final OptionKey<Boolean> CuMLEnabled = new OptionKey<>(true);
+    public static final OptionKey<Boolean> CuMLEnabled = new OptionKey<>(true, "CuMLEnabled");
 
     @Option(category = OptionCategory.USER, help = "Set the location of the cuml library.", stability = OptionStability.STABLE) //
-    public static final OptionKey<String> CuMLLibrary = new OptionKey<>(CUMLRegistry.DEFAULT_LIBRARY);
+    public static final OptionKey<String> CuMLLibrary = new OptionKey<>(CUMLRegistry.DEFAULT_LIBRARY, "CuMLLibrary");
 
     @Option(category = OptionCategory.USER, help = "Choose the scheduling policy of GrCUDA computations", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> ExecutionPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName());
+    public static final OptionKey<String> ExecutionPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName(), "ExecutionPolicy");
 
     @Option(category = OptionCategory.USER, help = "Choose how data dependencies between GrCUDA computations are computed", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> DependencyPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName());
+    public static final OptionKey<String> DependencyPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName(), "DependencyPolicy");
 
     @Option(category = OptionCategory.USER, help = "Choose how streams for new GrCUDA computations are created", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> RetrieveNewStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
+    public static final OptionKey<String> RetrieveNewStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName(), "RetrieveNewStreamPolicy");
 
     @Option(category = OptionCategory.USER, help = "Choose how streams for new GrCUDA computations are obtained from parent computations", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> RetrieveParentStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName());
+    public static final OptionKey<String> RetrieveParentStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName(), "RetrieveParentStreamPolicy");
 
     @Option(category = OptionCategory.USER, help = "Force the use of array stream attaching even when not required (e.g. post-Pascal GPUs)", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<Boolean> ForceStreamAttach = new OptionKey<>(false);
+    public static final OptionKey<Boolean> ForceStreamAttach = new OptionKey<>(false, "ForceStreamAttach");
 
     @Option(category = OptionCategory.USER, help = "Always prefetch input arrays to GPU if possible (e.g. post-Pascal GPUs)", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<Boolean> InputPrefetch = new OptionKey<>(false);
+    public static final OptionKey<Boolean> InputPrefetch = new OptionKey<>(false, "InputPrefetch");
 
     @Option(category = OptionCategory.USER, help = "Enable the option to set the current GPU in use", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<Boolean> EnableMultiGPU = new OptionKey<>(false);
+    public static final OptionKey<Boolean> EnableMultiGPU = new OptionKey<>(false, "EnableMultiGPU");
 
     @Option(category = OptionCategory.USER, help = "Enable TensorRT support.", stability = OptionStability.STABLE) //
-    public static final OptionKey<Boolean> TensorRTEnabled = new OptionKey<>(false);
+    public static final OptionKey<Boolean> TensorRTEnabled = new OptionKey<>(false, "TensorRTEnabled");
 
     @Option(category = OptionCategory.USER, help = "Set the location of the TensorRT library.", stability = OptionStability.STABLE) //
-    public static final OptionKey<String> TensorRTLibrary = new OptionKey<>(TensorRTRegistry.DEFAULT_LIBRARY);
+    public static final OptionKey<String> TensorRTLibrary = new OptionKey<>(TensorRTRegistry.DEFAULT_LIBRARY, "TensorRTLibrary");
 
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
@@ -44,6 +44,9 @@ import com.nvidia.grcuda.cudalibraries.cuml.CUMLRegistry;
 import com.nvidia.grcuda.cudalibraries.tensorrt.TensorRTRegistry;
 import com.oracle.truffle.api.Option;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Option.Group(GrCUDALanguage.ID)
 public final class GrCUDAOptions {
     private GrCUDAOptions() {
@@ -88,4 +91,22 @@ public final class GrCUDAOptions {
 
     @Option(category = OptionCategory.USER, help = "Set the location of the TensorRT library.", stability = OptionStability.STABLE) //
     public static final OptionKey<String> TensorRTLibrary = new OptionKey<>(TensorRTRegistry.DEFAULT_LIBRARY);
+
+    public static List<OptionKey<?>> getAll(){
+        List<OptionKey<?>> allOptions = new ArrayList<OptionKey<?>>();
+        allOptions.add(CuBLASEnabled);
+        allOptions.add(CuBLASLibrary);
+        allOptions.add(CuMLEnabled);
+        allOptions.add(CuMLLibrary);
+        allOptions.add(ExecutionPolicy);
+        allOptions.add(DependencyPolicy);
+        allOptions.add(RetrieveNewStreamPolicy);
+        allOptions.add(RetrieveParentStreamPolicy);
+        allOptions.add(ForceStreamAttach);
+        allOptions.add(InputPrefetch);
+        allOptions.add(EnableMultiGPU);
+        allOptions.add(TensorRTEnabled);
+        allOptions.add(TensorRTLibrary);
+        return allOptions;
+    }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
@@ -66,16 +66,16 @@ public final class GrCUDAOptions {
     public static final OptionKey<String> CuMLLibrary = new OptionKey<>(CUMLRegistry.DEFAULT_LIBRARY);
 
     @Option(category = OptionCategory.USER, help = "Choose the scheduling policy of GrCUDA computations", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> ExecutionPolicy = new OptionKey<>(GrCUDAContext.DEFAULT_EXECUTION_POLICY.getName());
+    public static final OptionKey<String> ExecutionPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_EXECUTION_POLICY.getName());
 
     @Option(category = OptionCategory.USER, help = "Choose how data dependencies between GrCUDA computations are computed", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> DependencyPolicy = new OptionKey<>(GrCUDAContext.DEFAULT_DEPENDENCY_POLICY.getName());
+    public static final OptionKey<String> DependencyPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_DEPENDENCY_POLICY.getName());
 
     @Option(category = OptionCategory.USER, help = "Choose how streams for new GrCUDA computations are created", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> RetrieveNewStreamPolicy = new OptionKey<>(GrCUDAContext.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
+    public static final OptionKey<String> RetrieveNewStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_RETRIEVE_STREAM_POLICY.getName());
 
     @Option(category = OptionCategory.USER, help = "Choose how streams for new GrCUDA computations are obtained from parent computations", stability = OptionStability.EXPERIMENTAL) //
-    public static final OptionKey<String> RetrieveParentStreamPolicy = new OptionKey<>(GrCUDAContext.DEFAULT_PARENT_STREAM_POLICY.getName());
+    public static final OptionKey<String> RetrieveParentStreamPolicy = new OptionKey<>(GrCUDAOptionMap.DEFAULT_PARENT_STREAM_POLICY.getName());
 
     @Option(category = OptionCategory.USER, help = "Force the use of array stream attaching even when not required (e.g. post-Pascal GPUs)", stability = OptionStability.EXPERIMENTAL) //
     public static final OptionKey<Boolean> ForceStreamAttach = new OptionKey<>(false);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAOptions.java
@@ -92,21 +92,4 @@ public final class GrCUDAOptions {
     @Option(category = OptionCategory.USER, help = "Set the location of the TensorRT library.", stability = OptionStability.STABLE) //
     public static final OptionKey<String> TensorRTLibrary = new OptionKey<>(TensorRTRegistry.DEFAULT_LIBRARY);
 
-    public static List<OptionKey<?>> getAll(){
-        List<OptionKey<?>> allOptions = new ArrayList<OptionKey<?>>();
-        allOptions.add(CuBLASEnabled);
-        allOptions.add(CuBLASLibrary);
-        allOptions.add(CuMLEnabled);
-        allOptions.add(CuMLLibrary);
-        allOptions.add(ExecutionPolicy);
-        allOptions.add(DependencyPolicy);
-        allOptions.add(RetrieveNewStreamPolicy);
-        allOptions.add(RetrieveParentStreamPolicy);
-        allOptions.add(ForceStreamAttach);
-        allOptions.add(InputPrefetch);
-        allOptions.add(EnableMultiGPU);
-        allOptions.add(TensorRTEnabled);
-        allOptions.add(TensorRTLibrary);
-        return allOptions;
-    }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cudalibraries/cublas/CUBLASRegistry.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cudalibraries/cublas/CUBLASRegistry.java
@@ -80,7 +80,7 @@ public class CUBLASRegistry {
 
     public CUBLASRegistry(GrCUDAContext context) {
         this.context = context;
-        libraryPath = context.getOption(GrCUDAOptions.CuBLASLibrary);
+        libraryPath = context.getOptions().getCuBLASLibrary();
     }
 
     public void ensureInitialized() {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cudalibraries/cuml/CUMLRegistry.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cudalibraries/cuml/CUMLRegistry.java
@@ -44,7 +44,6 @@ import java.util.List;
 import com.nvidia.grcuda.GrCUDAContext;
 import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.GrCUDAInternalException;
-import com.nvidia.grcuda.GrCUDAOptions;
 import com.nvidia.grcuda.Namespace;
 import com.nvidia.grcuda.cudalibraries.CUDALibraryFunction;
 import com.nvidia.grcuda.functions.ExternalFunctionFactory;
@@ -86,7 +85,7 @@ public class CUMLRegistry {
 
     public CUMLRegistry(GrCUDAContext context) {
         this.context = context;
-        libraryPath = context.getOption(GrCUDAOptions.CuMLLibrary);
+        libraryPath = context.getOptions().getCuMLLibrary();
     }
 
     private void ensureInitialized() {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cudalibraries/tensorrt/TensorRTRegistry.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cudalibraries/tensorrt/TensorRTRegistry.java
@@ -70,7 +70,7 @@ public class TensorRTRegistry {
 
     public TensorRTRegistry(GrCUDAContext context) {
         this.context = context;
-        libraryPath = context.getOption(GrCUDAOptions.TensorRTLibrary);
+        libraryPath = context.getOptions().getTensorRTLibrary();
         context.addDisposable(this::shutdown);
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/GetOptionsFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/GetOptionsFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, 2021, NECSTLab, Politecnico di Milano. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NECSTLab nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  * Neither the name of Politecnico di Milano nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+package com.nvidia.grcuda.functions;
+
+import com.nvidia.grcuda.GrCUDAOptionMap;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.UnsupportedTypeException;
+
+public class GetOptionsFunction extends Function{
+    private final GrCUDAOptionMap optionMap;
+
+    public GetOptionsFunction(GrCUDAOptionMap optionMap) {
+        super("getoptions");
+        this.optionMap = optionMap;
+    }
+
+    @Override
+    @CompilerDirectives.TruffleBoundary
+    public Object call(Object[] arguments) throws UnsupportedTypeException, ArityException {
+        checkArgumentLength(arguments, 0);
+        return optionMap;
+    }
+}

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/GetOptionsFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/GetOptionsFunction.java
@@ -29,15 +29,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 package com.nvidia.grcuda.functions;
 
 import com.nvidia.grcuda.GrCUDAOptionMap;
-import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 
-public class GetOptionsFunction extends Function{
+public class GetOptionsFunction extends Function {
     private final GrCUDAOptionMap optionMap;
 
     public GetOptionsFunction(GrCUDAOptionMap optionMap) {
@@ -46,7 +45,7 @@ public class GetOptionsFunction extends Function{
     }
 
     @Override
-    @CompilerDirectives.TruffleBoundary
+    @TruffleBoundary
     public Object call(Object[] arguments) throws UnsupportedTypeException, ArityException {
         checkArgumentLength(arguments, 0);
         return optionMap;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CUDARuntime.java
@@ -174,7 +174,7 @@ public final class CUDARuntime {
         this.architectureIsPascalOrNewer = cudaDeviceGetAttribute(CUDADeviceAttribute.COMPUTE_CAPABILITY_MAJOR, 0) >= 6;
 
         // Use pre-Pascal stream attachment policy if the CC is < 6 or if the attachment is forced by options;
-        this.streamAttachArchitecturePolicy = (!this.architectureIsPascalOrNewer || context.getOptionMap().isForceStreamAttach()) ? new PrePascalStreamAttachPolicy() : new PostPascalStreamAttachPolicy();
+        this.streamAttachArchitecturePolicy = (!this.architectureIsPascalOrNewer || context.getOptions().isForceStreamAttach()) ? new PrePascalStreamAttachPolicy() : new PostPascalStreamAttachPolicy();
     }
 
     // using this slow/uncached instance since all calls are non-critical
@@ -767,7 +767,7 @@ public final class CUDARuntime {
             public Object call(CUDARuntime cudaRuntime, Object[] args) throws ArityException, UnsupportedTypeException, InteropException {
                 checkArgumentLength(args, 1);
                 int device = expectInt(args[0]);
-                if (cudaRuntime.context.getOptionMap().isEnableMultiGPU()) {
+                if (cudaRuntime.context.getOptions().isEnableMultiGPU()) {
                     cudaRuntime.setLastDeviceUsed(device);
                 }
                 callSymbol(cudaRuntime, device);
@@ -1095,7 +1095,7 @@ public final class CUDARuntime {
 
     @TruffleBoundary
     public Kernel loadKernel(AbstractGrCUDAExecutionContext grCUDAExecutionContext, Binding binding) {
-        if (this.context.getOptionMap().isEnableMultiGPU()) {
+        if (this.context.getOptions().isEnableMultiGPU()) {
             return this.loadKernelMultiGPU(grCUDAExecutionContext, binding.getLibraryFileName(), binding.getName(), binding.getSymbolName(), binding.getNIDLParameterSignature());
         } else {
             return this.loadKernelSingleGPU(grCUDAExecutionContext, binding.getLibraryFileName(), binding.getName(), binding.getSymbolName(), binding.getNIDLParameterSignature());
@@ -1144,7 +1144,7 @@ public final class CUDARuntime {
         // System.out.println("buildKernel device:" + cudaGetDevice());
         String moduleName = "truffle" + context.getNextModuleId();
         PTXKernel ptx = nvrtc.compileKernel(code, kernelName, moduleName, "--std=c++14");
-        if (this.context.getOptionMap().isEnableMultiGPU()) {
+        if (this.context.getOptions().isEnableMultiGPU()) {
             return this.buildKernelMultiGPU(grCUDAExecutionContext, kernelName, signature, moduleName, ptx);
         } else {
             return this.buildKernelSingleGPU(grCUDAExecutionContext, kernelName, signature, moduleName, ptx);
@@ -1180,7 +1180,7 @@ public final class CUDARuntime {
     @TruffleBoundary
     public CUModule cuModuleLoad(String cubinName) {
         assertCUDAInitialized();
-        int currDevice = this.context.getOptionMap().isEnableMultiGPU() ? cudaGetDevice() : 0;
+        int currDevice = this.context.getOptions().isEnableMultiGPU() ? cudaGetDevice() : 0;
         if (this.loadedModules.get(currDevice).containsKey(cubinName)) {
             throw new GrCUDAException("A module for " + cubinName + " was already loaded.");
         }
@@ -1197,7 +1197,7 @@ public final class CUDARuntime {
     @TruffleBoundary
     public CUModule cuModuleLoadData(String ptx, String moduleName) {
         assertCUDAInitialized();
-        int currDevice = this.context.getOptionMap().isEnableMultiGPU() ? cudaGetDevice() : 0;
+        int currDevice = this.context.getOptions().isEnableMultiGPU() ? cudaGetDevice() : 0;
         if (this.loadedModules.get(currDevice).containsKey(moduleName)) {
             throw new GrCUDAException("A module for " + moduleName + " was already loaded.");
         }
@@ -1267,7 +1267,7 @@ public final class CUDARuntime {
         // using multiple gpu requires the stream associated to the device to be
         // set manually.
         long kernelFunctionHandle;
-        if (this.context.getOptionMap().isEnableMultiGPU()) {
+        if (this.context.getOptions().isEnableMultiGPU()) {
             stream.setDeviceId(this.lastDeviceSet);
             cudaSetDevice(stream.getStreamDeviceId());
             assert stream.getStreamDeviceId() == cudaGetDevice();
@@ -1412,7 +1412,7 @@ public final class CUDARuntime {
     private void assertCUDAInitialized() {
         if (!context.isCUDAInitialized()) {
             int currentDevice = cudaGetDevice();
-            if (this.context.getOptionMap().isEnableMultiGPU()) {
+            if (this.context.getOptions().isEnableMultiGPU()) {
                 int numDevices = cudaGetDeviceCount();
                 for (int i = 0; i < numDevices; i++) {
                     cudaSetDevice(i);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/CUDARuntime.java
@@ -174,7 +174,7 @@ public final class CUDARuntime {
         this.architectureIsPascalOrNewer = cudaDeviceGetAttribute(CUDADeviceAttribute.COMPUTE_CAPABILITY_MAJOR, 0) >= 6;
 
         // Use pre-Pascal stream attachment policy if the CC is < 6 or if the attachment is forced by options;
-        this.streamAttachArchitecturePolicy = (!this.architectureIsPascalOrNewer || context.isForceStreamAttach()) ? new PrePascalStreamAttachPolicy() : new PostPascalStreamAttachPolicy();
+        this.streamAttachArchitecturePolicy = (!this.architectureIsPascalOrNewer || context.getOptionMap().isForceStreamAttach()) ? new PrePascalStreamAttachPolicy() : new PostPascalStreamAttachPolicy();
     }
 
     // using this slow/uncached instance since all calls are non-critical
@@ -767,7 +767,7 @@ public final class CUDARuntime {
             public Object call(CUDARuntime cudaRuntime, Object[] args) throws ArityException, UnsupportedTypeException, InteropException {
                 checkArgumentLength(args, 1);
                 int device = expectInt(args[0]);
-                if (cudaRuntime.context.isEnableMultiGPU()) {
+                if (cudaRuntime.context.getOptionMap().isEnableMultiGPU()) {
                     cudaRuntime.setLastDeviceUsed(device);
                 }
                 callSymbol(cudaRuntime, device);
@@ -1095,7 +1095,7 @@ public final class CUDARuntime {
 
     @TruffleBoundary
     public Kernel loadKernel(AbstractGrCUDAExecutionContext grCUDAExecutionContext, Binding binding) {
-        if (this.context.isEnableMultiGPU()) {
+        if (this.context.getOptionMap().isEnableMultiGPU()) {
             return this.loadKernelMultiGPU(grCUDAExecutionContext, binding.getLibraryFileName(), binding.getName(), binding.getSymbolName(), binding.getNIDLParameterSignature());
         } else {
             return this.loadKernelSingleGPU(grCUDAExecutionContext, binding.getLibraryFileName(), binding.getName(), binding.getSymbolName(), binding.getNIDLParameterSignature());
@@ -1144,7 +1144,7 @@ public final class CUDARuntime {
         // System.out.println("buildKernel device:" + cudaGetDevice());
         String moduleName = "truffle" + context.getNextModuleId();
         PTXKernel ptx = nvrtc.compileKernel(code, kernelName, moduleName, "--std=c++14");
-        if (this.context.isEnableMultiGPU()) {
+        if (this.context.getOptionMap().isEnableMultiGPU()) {
             return this.buildKernelMultiGPU(grCUDAExecutionContext, kernelName, signature, moduleName, ptx);
         } else {
             return this.buildKernelSingleGPU(grCUDAExecutionContext, kernelName, signature, moduleName, ptx);
@@ -1180,7 +1180,7 @@ public final class CUDARuntime {
     @TruffleBoundary
     public CUModule cuModuleLoad(String cubinName) {
         assertCUDAInitialized();
-        int currDevice = this.context.isEnableMultiGPU() ? cudaGetDevice() : 0;
+        int currDevice = this.context.getOptionMap().isEnableMultiGPU() ? cudaGetDevice() : 0;
         if (this.loadedModules.get(currDevice).containsKey(cubinName)) {
             throw new GrCUDAException("A module for " + cubinName + " was already loaded.");
         }
@@ -1197,7 +1197,7 @@ public final class CUDARuntime {
     @TruffleBoundary
     public CUModule cuModuleLoadData(String ptx, String moduleName) {
         assertCUDAInitialized();
-        int currDevice = this.context.isEnableMultiGPU() ? cudaGetDevice() : 0;
+        int currDevice = this.context.getOptionMap().isEnableMultiGPU() ? cudaGetDevice() : 0;
         if (this.loadedModules.get(currDevice).containsKey(moduleName)) {
             throw new GrCUDAException("A module for " + moduleName + " was already loaded.");
         }
@@ -1267,7 +1267,7 @@ public final class CUDARuntime {
         // using multiple gpu requires the stream associated to the device to be
         // set manually.
         long kernelFunctionHandle;
-        if (this.context.isEnableMultiGPU()) {
+        if (this.context.getOptionMap().isEnableMultiGPU()) {
             stream.setDeviceId(this.lastDeviceSet);
             cudaSetDevice(stream.getStreamDeviceId());
             assert stream.getStreamDeviceId() == cudaGetDevice();
@@ -1412,7 +1412,7 @@ public final class CUDARuntime {
     private void assertCUDAInitialized() {
         if (!context.isCUDAInitialized()) {
             int currentDevice = cudaGetDevice();
-            if (this.context.isEnableMultiGPU()) {
+            if (this.context.getOptionMap().isEnableMultiGPU()) {
                 int numDevices = cudaGetDeviceCount();
                 for (int i = 0; i < numDevices; i++) {
                     cudaSetDevice(i);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/dependency/DependencyPolicyEnum.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/computation/dependency/DependencyPolicyEnum.java
@@ -40,7 +40,8 @@ public enum DependencyPolicyEnum {
         this.name = name;
     }
 
-    public String getName() {
+    @Override
+    public String toString() {
         return name;
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/ExecutionPolicyEnum.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/executioncontext/ExecutionPolicyEnum.java
@@ -40,7 +40,8 @@ public enum ExecutionPolicyEnum {
         this.name = name;
     }
 
-    public final String getName() {
+    @Override
+    public final String toString() {
         return name;
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/stream/GrCUDAStreamManager.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/stream/GrCUDAStreamManager.java
@@ -67,7 +67,7 @@ public class GrCUDAStreamManager {
     private final RetrieveParentStream retrieveParentStream;
 
     public GrCUDAStreamManager(CUDARuntime runtime) { 
-        this(runtime, runtime.getContext().getRetrieveNewStreamPolicy(), runtime.getContext().getRetrieveParentStreamPolicyEnum());
+        this(runtime, runtime.getContext().getOptionMap().getRetrieveNewStreamPolicy(), runtime.getContext().getOptionMap().getRetrieveParentStreamPolicy());
     }
 
     public GrCUDAStreamManager(

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/stream/GrCUDAStreamManager.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/stream/GrCUDAStreamManager.java
@@ -67,7 +67,7 @@ public class GrCUDAStreamManager {
     private final RetrieveParentStream retrieveParentStream;
 
     public GrCUDAStreamManager(CUDARuntime runtime) { 
-        this(runtime, runtime.getContext().getOptionMap().getRetrieveNewStreamPolicy(), runtime.getContext().getOptionMap().getRetrieveParentStreamPolicy());
+        this(runtime, runtime.getContext().getOptions().getRetrieveNewStreamPolicy(), runtime.getContext().getOptions().getRetrieveParentStreamPolicy());
     }
 
     public GrCUDAStreamManager(

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/stream/RetrieveNewStreamPolicyEnum.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/stream/RetrieveNewStreamPolicyEnum.java
@@ -40,7 +40,8 @@ public enum RetrieveNewStreamPolicyEnum {
         this.name = name;
     }
 
-    public String getName() {
+    @Override
+    public String toString() {
         return name;
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/stream/RetrieveParentStreamPolicyEnum.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/runtime/stream/RetrieveParentStreamPolicyEnum.java
@@ -40,7 +40,8 @@ public enum RetrieveParentStreamPolicyEnum {
         this.name = name;
     }
 
-    public String getName() {
+    @Override
+    public String toString() {
         return name;
     }
 }


### PR DESCRIPTION
Introduced a map for options.

- added GrCUDAOptionMap to know at runtime what are the options of the GrCUDA scheduler
- updates source code: options are now accessed as fields of OptionMap instead of GrCUDAContext
- added GetOptionsFunction class
- added tests for the new class
- added OptionValuesMock class as support for the tests